### PR TITLE
add error_msg to BaseReply failure schema

### DIFF
--- a/schemas/get_dynamic/reply_failure.schema.json
+++ b/schemas/get_dynamic/reply_failure.schema.json
@@ -10,6 +10,20 @@
       "const": "failure",
       "title": "Status",
       "type": "string"
+    },
+    "payload": {
+      "properties": {
+        "error_msg": {
+          "description": "A descriptive error message to be passed on to the user.",
+          "title": "Error Msg",
+          "type": "string"
+        }
+      },
+      "required": [
+        "error_msg"
+      ],
+      "title": "QuantumHardwareFailureData",
+      "type": "object"
     }
   },
   "required": [

--- a/schemas/get_static/reply_failure.schema.json
+++ b/schemas/get_static/reply_failure.schema.json
@@ -10,6 +10,20 @@
       "const": "failure",
       "title": "Status",
       "type": "string"
+    },
+    "payload": {
+      "properties": {
+        "error_msg": {
+          "description": "A descriptive error message to be passed on to the user.",
+          "title": "Error Msg",
+          "type": "string"
+        }
+      },
+      "required": [
+        "error_msg"
+      ],
+      "title": "QuantumHardwareFailureData",
+      "type": "object"
     }
   },
   "required": [

--- a/tests/control-software-validator/models/get_dynamic_reply_failure.py
+++ b/tests/control-software-validator/models/get_dynamic_reply_failure.py
@@ -3,11 +3,20 @@
 
 from __future__ import annotations
 
-from typing import Literal
+from typing import Literal, Optional
 
 from pydantic import BaseModel, Field
+
+
+class Payload(BaseModel):
+    error_msg: str = Field(
+        ...,
+        description='A descriptive error message to be passed on to the user.',
+        title='Error Msg',
+    )
 
 
 class GetDynamicReplyFailure(BaseModel):
     version: str = Field(..., pattern='^\\d+\\.\\d+\\.\\d$', title='Version')
     status: Literal['failure'] = Field(..., title='Status')
+    payload: Optional[Payload] = Field(None, title='QuantumHardwareFailureData')

--- a/tests/control-software-validator/models/get_static_reply_failure.py
+++ b/tests/control-software-validator/models/get_static_reply_failure.py
@@ -3,11 +3,20 @@
 
 from __future__ import annotations
 
-from typing import Literal
+from typing import Literal, Optional
 
 from pydantic import BaseModel, Field
+
+
+class Payload(BaseModel):
+    error_msg: str = Field(
+        ...,
+        description='A descriptive error message to be passed on to the user.',
+        title='Error Msg',
+    )
 
 
 class GetStaticReplyFailure(BaseModel):
     version: str = Field(..., pattern='^\\d+\\.\\d+\\.\\d$', title='Version')
     status: Literal['failure'] = Field(..., title='Status')
+    payload: Optional[Payload] = Field(None, title='QuantumHardwareFailureData')


### PR DESCRIPTION
According to the documentation, all BaseReply failure messages must contain `payload.error_msg`, but there is no mention of this in the JSON schema. As a consequence, the generated Python Pydantic models cannot be used to generate failure messages with an `error_msg`.

This PR modifies the schema so that an `error_msg` is present.

This PR does *not* make `error_msg` required, even though the docs require it. Doing so would make the generated Pydantic models incompatible with other Python codes that might use these.