### PR TITLE
[QI2-1617] Fix pgs description

### DIFF
--- a/docs/request/meta.md
+++ b/docs/request/meta.md
@@ -34,7 +34,7 @@ This message does not require any additional information in the payload section.
 | `nqubits` | `int` | The number of qubits |
 | `topology` | `array[tuple]` | List of the edges between the various qubits |
 | `name` | `str` | Name of the system |
-| `pgs` | `array[str]` | Supported primitive gates set of the system. Gate names as described in cQASM (in uppercase) |
+| `pgs` | `array[str]` | Supported primitive gates set of the system. Gate names as described `instructions` (bottom of file) in [QuIS](https://github.com/QuTech-Delft/QuIS/blob/develop/quis/quis.json) |
 | `starttime` | `float` | Timestamp of start-up of the system (return value of `time.time()`) |
 | `default_compiler_config` | `object[str,array[object[str, Any]]]` | Compiler configurations for different stages. |
 | `supports_raw_data` | `bool` | Default `False`. Whether the hardware backend supports `raw_data`. If `True`, the `include_raw_data` flag in the [execute message](execute.md#execute-request-payload) should trigger the backend to store the measurements per shot in the raw_data field of the results. |


### PR DESCRIPTION
This pull request updates the documentation for the `pgs` field in the `docs/request/meta.md` file to provide a more accurate description and reference for the supported primitive gates.

### Documentation Update:
* [`docs/request/meta.md`](diffhunk://#diff-6e3d37c7dec63d1f901c6be0c7d672d14f10d0cb153b69b9876d88d06290cce5L37-R37): Updated the description of the `pgs` field to reference gate names as described in the `instructions` section of the [QuIS](https://github.com/QuTech-Delft/QuIS/blob/develop/quis/quis.json) repository.